### PR TITLE
The endDateTimeIndex closing tag was missing

### DIFF
--- a/query_v14/get_log_subset_rows_by_time.xml
+++ b/query_v14/get_log_subset_rows_by_time.xml
@@ -3,7 +3,7 @@
    <log uidWell="%uidWell%" uidWellbore="%uidWellbore%" uid="%uidLog%">
       <dataRowCount />
       <startDateTimeIndex>%startDateTimeIndex%</startDateTimeIndex>
-      <endDateTimeIndex>%endDateTimeIndex%</startDateTimeIndex>
+      <endDateTimeIndex>%endDateTimeIndex%</endDateTimeIndex>
       <logCurveInfo>
          <mnemonic />
          <minDateTimeIndex />


### PR DESCRIPTION
The endDateTimeIndex doesn't have a closing tag. There are two startDateTimeIndex closing tags.
